### PR TITLE
Fixed path to MAP_SHARED constant.

### DIFF
--- a/src/v4l2.rs
+++ b/src/v4l2.rs
@@ -6,7 +6,7 @@ use std::{io, mem, usize};
 use libc::{c_void, c_ulong, size_t, off_t};
 use libc::timeval as Timeval;
 use libc::{O_RDWR, PROT_READ, PROT_WRITE};
-use libc::consts::os::posix88::{MAP_SHARED};
+use libc::{MAP_SHARED};
 
 
 #[cfg(not(feature = "no_wrapper"))]


### PR DESCRIPTION
Couldn't compile because libc constants seem to have moved from libc::consts::os::posix88 to libc::. This change will make it compile again.