### PR TITLE
Added ioctls for FreeBSD

### DIFF
--- a/src/v4l2.rs
+++ b/src/v4l2.rs
@@ -1236,8 +1236,14 @@ pub const VIDIOC_QUERY_EXT_CTRL: usize = 3236451943;
 pub const VIDIOC_QUERYMENU: usize = 3224131109;
 pub const VIDIOC_REQBUFS: usize = 3222558216;
 pub const VIDIOC_S_PARM: usize = 3234616854;
+#[cfg(target_os = "linux")]
 pub const VIDIOC_STREAMOFF: usize = 1074026003;
+#[cfg(target_os = "freebsd")]
+pub const VIDIOC_STREAMOFF: usize = 2147767827;
+#[cfg(target_os = "linux")]
 pub const VIDIOC_STREAMON: usize = 1074026002;
+#[cfg(target_os = "freebsd")]
+pub const VIDIOC_STREAMON: usize = 2147767826;
 
 #[cfg(target_pointer_width = "64")]
 pub const VIDIOC_DQBUF: usize = 3227014673;


### PR DESCRIPTION
STREAMON/STREAMOFF is different for FreeBSD so I added conditions for these. All examples now run without problem on FreeBSD so it might be only these two that are different.