### PR TITLE
Expose frame timestamp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rscam"
-version = "0.5.3"
+version = "0.5.4"
 description = "Wrapper for v4l2."
 keywords = ["v4l2", "video", "camera", "capture"]
 authors = ["Paul Loyd <pavelko95@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,15 @@ pub struct Frame {
     buffer: v4l2::Buffer
 }
 
+impl Frame {
+    /// Return frame timestamp in microseconds using monotonically
+    /// nondecreasing clock
+    pub fn get_timestamp(&self) -> u64 {
+        let t = self.buffer.timestamp;
+        1_000_000*(t.tv_sec as u64) + (t.tv_usec as u64)
+    }
+}
+
 impl Deref for Frame {
     type Target = [u8];
 


### PR DESCRIPTION
This functionality can be quite useful for detecting frame drops and for more precise measurement of relative frame timings.

P.S.: I agree with potential re-licensing under MIT/Apache-2.0.