### PR TITLE
feat: static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ libc = "0.2"
 
 [features]
 no_wrapper = []
+static = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "static")]
+fn main() {
+    println!("cargo:rustc-link-lib=static=v4l2");
+    println!("cargo:rustc-link-lib=static=v4lconvert");
+    println!("cargo:rustc-link-lib=static=jpeg");
+}
+
+#[cfg(not(feature = "static"))]
+fn main() {}

--- a/src/v4l2.rs
+++ b/src/v4l2.rs
@@ -21,7 +21,8 @@ mod ll {
     pub use self::v4l2_munmap as munmap;
     pub use self::v4l2_open as open;
 
-    #[link(name = "v4l2")]
+    #[cfg_attr(feature = "static", link(name = "v4l2", kind = "static"))]
+    #[cfg_attr(not(feature = "static"), link(name = "v4l2"))]
     extern "C" {
         pub fn v4l2_open(file: *const c_char, flags: c_int, arg: c_int) -> RawFd;
         pub fn v4l2_close(fd: RawFd) -> c_int;


### PR DESCRIPTION
Enabling the `static` cargo feature will link libv4l2, libv4lconvert, and libjpeg statically.