### PR TITLE
Fix v4l2 wrapper usage for 32 bit systems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,13 +190,22 @@ impl fmt::Debug for IntervalInfo {
 
                 Ok(())
             }
-            IntervalInfo::Stepwise { min, max, step } => write!(
-                f,
-                "Stepwise from {}fps to {}fps by {}fps",
-                max.1 / max.0,
-                min.1 / min.0,
-                step.1 / step.0
-            ),
+            IntervalInfo::Stepwise { min, max, step }
+                if min.0 != 0 && max.0 != 0 && step.0 != 0 =>
+            {
+                write!(
+                    f,
+                    "Stepwise from {}fps to {}fps by {}fps",
+                    max.1 / max.0,
+                    min.1 / min.0,
+                    step.1 / step.0
+                )
+            }
+            IntervalInfo::Stepwise {
+                min: _,
+                max: _,
+                step: _,
+            } => write!(f, "Invalid stepwise interval info with 0 denominators"),
         }
     }
 }


### PR DESCRIPTION
Hi,
when trying out rscam on Ubuntu 20.04 armhf (Armbian on BananaPI M1), I saw that the build with standard features (i.e. with the v4l wrappers) failed to mmap, while the "no_wrapper" build worked fine (but of course could not do any format conversions). Turns out that mmap and v4l_mmap have a nasty signature mismatch that's not reflected in rscam.